### PR TITLE
Add the .dotfiles bin to PATH

### DIFF
--- a/zsh/.zprofile
+++ b/zsh/.zprofile
@@ -31,4 +31,4 @@ if [[ ":${PATH}:" != *":${PNPM_HOME}:"* ]]; then
 fi
 
 # --- personal bin
-export PATH="${HOME}/.local/bin:${PATH}"
+export PATH="${HOME}/.dotfiles/bin:${PATH}"


### PR DESCRIPTION
This PR Closes #1 by adding `.dotfiles/bin` to the users path. This is a more simple approach to adding custom scripts and executables as we know it will be present and avoids adding a users local bin automatically which may be undesirable.